### PR TITLE
In DHCP use default renewal and rebinding times

### DIFF
--- a/dhcp/src/lib.rs
+++ b/dhcp/src/lib.rs
@@ -432,22 +432,6 @@ impl<'a> Client<'a> {
                             let dns: Option<Ipv4Addr> = pkt.dns()?;
                             let ntp: Option<Ipv4Addr> = pkt.ntp()?;
 
-                            let renewal_time: u32 = match pkt.renewal_time()? {
-                                Some(x) => x,
-                                None => {
-                                    error!("renewal_time option missing");
-                                    return Ok(self.next_call(monotonic_secs));
-                                }
-                            };
-                            info!("renewal_time: {}", renewal_time);
-                            let rebinding_time: u32 = match pkt.rebinding_time()? {
-                                Some(x) => x,
-                                None => {
-                                    error!("rebinding_time option missing");
-                                    return Ok(self.next_call(monotonic_secs));
-                                }
-                            };
-                            info!("rebinding_time: {}", rebinding_time);
                             let lease_time: u32 = match pkt.lease_time()? {
                                 Some(x) => x,
                                 None => {
@@ -456,6 +440,16 @@ impl<'a> Client<'a> {
                                 }
                             };
                             info!("lease_time: {}", lease_time);
+                            let renewal_time: u32 = match pkt.renewal_time()? {
+                                Some(x) => x,
+                                None => lease_time / 2,
+                            };
+                            info!("renewal_time: {}", renewal_time);
+                            let rebinding_time: u32 = match pkt.rebinding_time()? {
+                                Some(x) => x,
+                                None => lease_time * 7 / 8,
+                            };
+                            info!("rebinding_time: {}", rebinding_time);
 
                             // de-rate times by 12%
                             self.t1 = renewal_time.saturating_sub(renewal_time / 8);

--- a/dhcp/src/lib.rs
+++ b/dhcp/src/lib.rs
@@ -447,7 +447,7 @@ impl<'a> Client<'a> {
                             info!("renewal_time: {}", renewal_time);
                             let rebinding_time: u32 = match pkt.rebinding_time()? {
                                 Some(x) => x,
-                                None => lease_time * 7 / 8,
+                                None => lease_time.saturating_mul(7) / 8,
                             };
                             info!("rebinding_time: {}", rebinding_time);
 


### PR DESCRIPTION
I am using the ethernet, DHCP, DNS and MQTT implementations of this repository with great success. At my office the DHCP server though does not provide the Renewal Time (option 58) and Rebinding Time (option 59). Thus to make it work we can use the default times for these as used by many DHCP clients. I do not believe that these values are standardized in a RFC.