### PR TITLE
tls: use p256-cortex-m4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ default-members = [
     "sntp",
     "tls",
 ]
+
+[patch.crates-io]
+p256-cortex-m4-sys.path = "/home/alex/git/p256-cortex-m4-sys"
+p256-cortex-m4.path = "/home/alex/git/p256-cortex-m4"

--- a/tls/Cargo.toml
+++ b/tls/Cargo.toml
@@ -22,10 +22,10 @@ w5500-hl = { path = "../hl", version = "0.9.0" }
 heapless = { version = "0.7", default-features = false }
 hkdf = { version = "0.12", default-features = false }
 hmac = { version = "0.12", default-features = false }
-p256 = { version = "0.11", default-features = false, features = ["arithmetic", "ecdh"] }
 rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
+p256-cortex-m4 = { version = "0.1.0-alpha.6" }
 
 # optional
 defmt = { version = "0.3", optional = true }

--- a/tls/src/handshake/client_hello.rs
+++ b/tls/src/handshake/client_hello.rs
@@ -523,7 +523,7 @@ pub fn ser(
     buf: &mut [u8],
     random: &[u8; 32],
     hostname: &Hostname,
-    client_secret: &p256::EncodedPoint,
+    client_public: &p256_cortex_m4::PublicKey,
     key_schedule: &mut KeySchedule,
     psk: &[u8],
     identity: &[u8],
@@ -595,7 +595,7 @@ pub fn ser(
             P256_UNCOMPRESSED_POINT_SIZE as u8,
         ];
         writer.copy_from_slice(&KEY_SHARE_EXTENSION_HEADER);
-        writer.copy_from_slice(client_secret.as_bytes());
+        writer.copy_from_slice(&client_public.to_uncompressed_sec1_bytes());
     }
 
     // record size limit

--- a/tls/src/handshake/server_hello.rs
+++ b/tls/src/handshake/server_hello.rs
@@ -2,6 +2,8 @@ use crate::{
     cipher_suites::CipherSuite, io::CircleReader, AlertDescription, ExtensionType, NamedGroup,
     TlsVersion,
 };
+use p256_cortex_m4::PublicKey;
+
 const P256_KEY_LEN: usize = 65;
 
 /// Server Hello key exchange message.
@@ -20,9 +22,7 @@ const P256_KEY_LEN: usize = 65;
 ///     Extension extensions<6..2^16-1>;
 /// } ServerHello;
 /// ```
-pub(crate) fn recv_server_hello(
-    reader: &mut CircleReader,
-) -> Result<p256::PublicKey, AlertDescription> {
+pub(crate) fn recv_server_hello(reader: &mut CircleReader) -> Result<PublicKey, AlertDescription> {
     let legacy_version: u16 = reader.next_u16()?;
     const EXPECTED_LEGACY_VERSION: u16 = TlsVersion::V1_2 as u16;
     if legacy_version != EXPECTED_LEGACY_VERSION {
@@ -191,7 +191,7 @@ pub(crate) fn recv_server_hello(
         return Err(AlertDescription::MissingExtension);
     }
 
-    match p256::PublicKey::from_sec1_bytes(&key_buf) {
+    match PublicKey::from_sec1_bytes(&key_buf) {
         Ok(public_key) => Ok(public_key),
         Err(_e) => {
             #[cfg(feature = "log")]

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -79,6 +79,7 @@ use hl::{
 use io::Buffer;
 pub use io::{TlsReader, TlsWriter};
 use key_schedule::KeySchedule;
+use p256_cortex_m4::PublicKey;
 pub use rand_core;
 use rand_core::{CryptoRng, RngCore};
 use record::{ContentType, RecordHeader};
@@ -1001,8 +1002,7 @@ impl<'hn, 'psk, 'b, const N: usize> Client<'hn, 'psk, 'b, N> {
                         error!("unexpected ServerHello in state {:?}", self.state);
                         return Err(AlertDescription::UnexpectedMessage);
                     } else {
-                        let public_key: p256::PublicKey =
-                            handshake::recv_server_hello(&mut reader)?;
+                        let public_key: PublicKey = handshake::recv_server_hello(&mut reader)?;
 
                         self.key_schedule.set_server_public_key(public_key);
                         self.key_schedule.set_transcript_hash(hash.clone());


### PR DESCRIPTION
Saves ~16k flash on cortex-m4 targets, and it is significantly faster.

Need to find a more elegant way to include this.

| section |   p256 | p256-cortex-m4 |     Δ  |
|---------|--------|----------------|--------|
| .text   | 170188 |         157664 | -12524 |
| .rodata |  50816 |          46896 |  -3920 |

