### PR TITLE
dhcp,ll: derive defmt::Format for logged structs

### DIFF
--- a/dhcp/src/pkt.rs
+++ b/dhcp/src/pkt.rs
@@ -47,6 +47,7 @@ impl From<Options> for u8 {
 /// From [RFC 2132 Section 9.6](https://tools.ietf.org/html/rfc2132#section-9.6)
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MsgType {
     /// DHCPDISCOVER
     Discover = 1,

--- a/ll/src/registers.rs
+++ b/ll/src/registers.rs
@@ -463,6 +463,7 @@ impl ::core::fmt::Display for Interrupt {
 /// [`Registers::phycfgr`]: crate::Registers::phycfgr
 /// [`Registers::set_phycfgr`]: crate::Registers::set_phycfgr
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PhyCfg(u8);
 impl_boilerplate_for!(PhyCfg);
 


### PR DESCRIPTION
I had to add these `derive`s to be able to build `w5500-dhcp` successfully with the `defmt` feature enabled, since `PhyCfg` and `MsgType` are both logged to `defmt` in `dhcp/src/lib.rs`.