### PR TITLE
Untangle error types for embedded-hal 1.*.* impls

### DIFF
--- a/ll/src/eh1/fdm.rs
+++ b/ll/src/eh1/fdm.rs
@@ -21,9 +21,9 @@ pub struct W5500<SPI> {
     spi: SPI,
 }
 
-impl<SPI, SpiError> W5500<SPI>
+impl<SPI> W5500<SPI>
 where
-    SPI: eh1::spi::SpiBus<u8, Error = SpiError>,
+    SPI: eh1::spi::SpiBus<u8>,
 {
     /// Creates a new `W5500` driver from a SPI bus.
     ///
@@ -59,12 +59,12 @@ where
     }
 }
 
-impl<SPI, SpiError> crate::Registers for W5500<SPI>
+impl<SPI> crate::Registers for W5500<SPI>
 where
-    SPI: eh1::spi::SpiBus<u8, Error = SpiError>,
+    SPI: eh1::spi::SpiBus<u8>,
 {
     /// SPI IO error type.
-    type Error = SpiError;
+    type Error = SPI::Error;
 
     /// Read from the W5500.
     #[allow(clippy::while_let_on_iterator)]


### PR DESCRIPTION
The error type specified by a SpiDevice does not need to be the same as what is returned by the underlying SpiBus. The correct thing to do is to get the error by treating the SpiDevice as a spi::ErrorType.

An unncessary type variable on the FDM SpiBus implementation was removed by using spi::ErrorType::Error directly as well.