### PR TITLE
treewide: add support for ip_in_core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,20 @@ jobs:
         if: ${{ matrix.target == 'thumbv7em-none-eabi' }}
       - run: cargo build --target ${{ matrix.target }} -p w5500-mqtt --features w5500-tls,p256-cm4
         if: ${{ matrix.target == 'thumbv7em-none-eabi' }}
+      - run: cargo build --target ${{ matrix.target }} -p w5500-ll   --features ip_in_core
+        if: ${{ matrix.toolchain == 'nightly' }}
+      - run: cargo build --target ${{ matrix.target }} -p w5500-ll   --features ip_in_core,defmt
+        if: ${{ matrix.toolchain == 'nightly' }}
+      - run: cargo build --target ${{ matrix.target }} -p w5500-hl   --features ip_in_core
+        if: ${{ matrix.toolchain == 'nightly' }}
+      - run: cargo build --target ${{ matrix.target }} -p w5500-dhcp --features ip_in_core
+        if: ${{ matrix.toolchain == 'nightly' }}
+      - run: cargo build --target ${{ matrix.target }} -p w5500-dns  --features ip_in_core
+        if: ${{ matrix.toolchain == 'nightly' }}
+      - run: cargo build --target ${{ matrix.target }} -p w5500-mqtt --features ip_in_core
+        if: ${{ matrix.toolchain == 'nightly' }}
+      - run: cargo build --target ${{ matrix.target }} -p w5500-tls  --features ip_in_core
+        if: ${{ matrix.toolchain == 'nightly' }}
 
   test:
     name: Test

--- a/dhcp/Cargo.toml
+++ b/dhcp/Cargo.toml
@@ -12,14 +12,15 @@ categories = ["embedded", "hardware-support", "no-std"]
 homepage = "https://github.com/newAM/w5500-rs"
 
 [features]
+defmt = ["w5500-hl/defmt", "dep:defmt"]
 eh0 = ["w5500-hl/eh0"]
 eh1 = ["w5500-hl/eh1"]
-defmt = ["w5500-hl/defmt", "dep:defmt"]
+ip_in_core = ["w5500-hl/ip_in_core"]
 std = ["w5500-hl/std"]
 
 [dependencies]
 w5500-hl = { path = "../hl", version = "0.9.0" }
-defmt = { version = "0.3", optional = true }
+defmt = { version = "0.3.4", optional = true }
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/dhcp/README.md
+++ b/dhcp/README.md
@@ -13,6 +13,7 @@ All features are disabled by default.
 
 * `eh0`: Passthrough to [`w5500-hl`].
 * `eh1`: Passthrough to [`w5500-hl`].
+* `ip_in_core`: Passthrough to [`w5500-hl`].
 * `std`: Passthrough to [`w5500-hl`].
 * `defmt`: Enable logging with `defmt`. Also a passthrough to [`w5500-hl`].
 * `log`: Enable logging with `log`.

--- a/dhcp/src/lib.rs
+++ b/dhcp/src/lib.rs
@@ -11,6 +11,7 @@
 //!
 //! * `eh0`: Passthrough to [`w5500-hl`].
 //! * `eh1`: Passthrough to [`w5500-hl`].
+//! * `ip_in_core`: Passthrough to [`w5500-hl`].
 //! * `std`: Passthrough to [`w5500-hl`].
 //! * `defmt`: Enable logging with `defmt`. Also a passthrough to [`w5500-hl`].
 //! * `log`: Enable logging with `log`.

--- a/dhcp/src/pkt.rs
+++ b/dhcp/src/pkt.rs
@@ -211,7 +211,7 @@ impl<'a, W: Registers> PktSer<'a, W> {
     /// respond to ARP requests.
     fn set_ciaddr(&mut self, addr: &Ipv4Addr) -> Result<(), Error<W::Error>> {
         self.writer.seek(SeekFrom::Start(12))?;
-        self.writer.write_all(&addr.octets)
+        self.writer.write_all(&addr.octets())
     }
 
     /// 'your' (client) IP address;
@@ -219,20 +219,20 @@ impl<'a, W: Registers> PktSer<'a, W> {
     /// know its own address (ciaddr was 0).
     fn set_yiaddr(&mut self, addr: &Ipv4Addr) -> Result<(), Error<W::Error>> {
         self.writer.seek(SeekFrom::Start(16))?;
-        self.writer.write_all(&addr.octets)
+        self.writer.write_all(&addr.octets())
     }
 
     /// Set the IP address of next server to use in bootstrap;
     /// returned in DHCPOFFER, DHCPACK by server.
     fn set_siaddr(&mut self, addr: &Ipv4Addr) -> Result<(), Error<W::Error>> {
         self.writer.seek(SeekFrom::Start(20))?;
-        self.writer.write_all(&addr.octets)
+        self.writer.write_all(&addr.octets())
     }
 
     /// Relay agent IP address, used in booting via a relay agent.
     fn set_giaddr(&mut self, addr: &Ipv4Addr) -> Result<(), Error<W::Error>> {
         self.writer.seek(SeekFrom::Start(24))?;
-        self.writer.write_all(&addr.octets)
+        self.writer.write_all(&addr.octets())
     }
 
     /// Set the hardware address
@@ -307,7 +307,7 @@ impl<'a, W: Registers> PktSer<'a, W> {
 
     fn set_option_requested_ip(&mut self, ip: &Ipv4Addr) -> Result<(), Error<W::Error>> {
         self.writer.write_all(&[Options::RequestedIp.into(), 4])?;
-        self.writer.write_all(&ip.octets)
+        self.writer.write_all(&ip.octets())
     }
 
     fn set_option_end(&mut self) -> Result<(), Error<W::Error>> {

--- a/dhcp/tests/end_to_end.rs
+++ b/dhcp/tests/end_to_end.rs
@@ -205,7 +205,7 @@ fn end_to_end() {
         .set_hops(0)
         .set_xid(msg.xid())
         .set_flags(Flags::default().set_broadcast())
-        .set_chaddr(&Ipv4Addr::LOCALHOST.octets)
+        .set_chaddr(&Ipv4Addr::LOCALHOST.octets())
         .set_yiaddr(YIADDR)
         .opts_mut()
         .insert(DhcpOption::MessageType(MessageType::Offer));
@@ -225,7 +225,7 @@ fn end_to_end() {
         .set_hops(0)
         .set_xid(msg.xid())
         .set_flags(Flags::default().set_broadcast())
-        .set_chaddr(&Ipv4Addr::LOCALHOST.octets)
+        .set_chaddr(&Ipv4Addr::LOCALHOST.octets())
         .set_yiaddr([1, 2, 3, 4])
         .opts_mut()
         .insert(DhcpOption::MessageType(MessageType::Ack));

--- a/dns/Cargo.toml
+++ b/dns/Cargo.toml
@@ -12,14 +12,15 @@ categories = ["embedded", "hardware-support", "no-std"]
 homepage = "https://github.com/newAM/w5500-rs"
 
 [features]
+defmt = ["w5500-hl/defmt", "dep:defmt"]
 eh0 = ["w5500-hl/eh0"]
 eh1 = ["w5500-hl/eh1"]
-defmt = ["w5500-hl/defmt", "dep:defmt"]
+ip_in_core = ["w5500-hl/ip_in_core"]
 std = ["w5500-hl/std"]
 
 [dependencies]
 w5500-hl = { path = "../hl", version = "0.9.0" }
-defmt = { version = "0.3", optional = true }
+defmt = { version = "0.3.4", optional = true }
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/dns/README.md
+++ b/dns/README.md
@@ -50,12 +50,13 @@ response.done()?;
 
 All features are disabled by default.
 
-* `eh0`: Passthrough to [w5500-hl].
-* `eh1`: Passthrough to [w5500-hl].
-* `std`: Passthrough to [w5500-hl].
+* `eh0`: Passthrough to [`w5500-hl`].
+* `eh1`: Passthrough to [`w5500-hl`].
+* `ip_in_core`: Passthrough to [`w5500-hl`].
+* `std`: Passthrough to [`w5500-hl`].
 * `defmt`: Enable logging with `defmt`. Also a passthrough to [w5500-hl].
 * `log`: Enable logging with `log`.
 
-[w5500-hl]: https://crates.io/crates/w5500-hl
+[`w5500-hl`]: https://crates.io/crates/w5500-hl
 [`std::net`]: https://doc.rust-lang.org/std/net/index.html
 [Wiznet W5500]: https://www.wiznet.io/product-item/w5500/

--- a/dns/src/lib.rs
+++ b/dns/src/lib.rs
@@ -51,13 +51,14 @@
 //!
 //! All features are disabled by default.
 //!
-//! * `eh0`: Passthrough to [w5500-hl].
-//! * `eh1`: Passthrough to [w5500-hl].
-//! * `std`: Passthrough to [w5500-hl].
+//! * `eh0`: Passthrough to [`w5500-hl`].
+//! * `eh1`: Passthrough to [`w5500-hl`].
+//! * `ip_in_core`: Passthrough to [`w5500-hl`].
+//! * `std`: Passthrough to [`w5500-hl`].
 //! * `defmt`: Enable logging with `defmt`. Also a passthrough to [w5500-hl].
 //! * `log`: Enable logging with `log`.
 //!
-//! [w5500-hl]: https://crates.io/crates/w5500-hl
+//! [`w5500-hl`]: https://crates.io/crates/w5500-hl
 //! [`std::net`]: https://doc.rust-lang.org/std/net/index.html
 //! [Wiznet W5500]: https://www.wiznet.io/product-item/w5500/
 #![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))]

--- a/dns/tests/response.rs
+++ b/dns/tests/response.rs
@@ -64,7 +64,7 @@ impl Registers for MockW5500 {
             // reading the UDP header
             assert_eq!(buf.len(), UDP_HEADER_LEN);
 
-            buf[..4].copy_from_slice(&self.header.origin.ip().octets);
+            buf[..4].copy_from_slice(&self.header.origin.ip().octets());
             buf[4..6].copy_from_slice(&self.header.origin.port().to_be_bytes());
             buf[6..8].copy_from_slice(&self.header.len.to_be_bytes());
         } else {

--- a/hl/Cargo.toml
+++ b/hl/Cargo.toml
@@ -15,10 +15,11 @@ homepage = "https://github.com/newAM/w5500-rs"
 defmt = ["w5500-ll/defmt", "dep:defmt"]
 eh0 = ["w5500-ll/eh0"]
 eh1 = ["w5500-ll/eh1"]
+ip_in_core = ["w5500-ll/ip_in_core"]
 std = ["w5500-ll/std"]
 
 [dependencies]
-defmt = { version = "0.3", optional = true }
+defmt = { version = "0.3.4", optional = true }
 w5500-ll = { path = "../ll", version = "0.10" }
 
 [dev-dependencies]

--- a/hl/README.md
+++ b/hl/README.md
@@ -26,6 +26,7 @@ All features are disabled by default.
 * `defmt`: Passthrough to [`w5500-ll`].
 * `eh0`: Passthrough to [`w5500-ll`].
 * `eh1`: Passthrough to [`w5500-ll`].
+* `ip_in_core`: Passthrough to [`w5500-ll`].
 * `std`: Passthrough to [`w5500-ll`].
 
 ## Examples

--- a/hl/src/lib.rs
+++ b/hl/src/lib.rs
@@ -24,6 +24,7 @@
 //! * `defmt`: Passthrough to [`w5500-ll`].
 //! * `eh0`: Passthrough to [`w5500-ll`].
 //! * `eh1`: Passthrough to [`w5500-ll`].
+//! * `ip_in_core`: Passthrough to [`w5500-ll`].
 //! * `std`: Passthrough to [`w5500-ll`].
 //!
 //! # Examples

--- a/ll/CHANGELOG.md
+++ b/ll/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added `#[must_use]` to functions in `w5500_ll::net`.
+- Added support for `core::net` types with the `ip_in_core` feature.
 - Added support for `embedded-hal` version `1.0.0-alpha.10` with the `eh1` feature.
 - Added support for `embedded-hal-async` version `0.2.0-alpha.0` with the `eha0a` feature.
 - Added an `aio` module with async traits.
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the `embedded-hal` version `0.2` feature name to `eh0`.
 - Renamed the `blocking` module to `eh0`.
 - Moved the `reset` function into the `eh0` and `eh1` modules.
+- Replaced public `octets` member on `net::Ipv4Addr` with an `octets()` method.
 
 ## [0.10.4] - 2022-07-14
 ### Added

--- a/ll/Cargo.toml
+++ b/ll/Cargo.toml
@@ -12,13 +12,15 @@ categories = ["embedded", "hardware-support", "no-std"]
 homepage = "https://github.com/newAM/w5500-rs"
 
 [features]
-std = []
 async = []
-eha0a = ["async", "dep:eha0a", "dep:eh1"]
+defmt = ["dep:defmt"]
 eh1 = ["dep:eh1"]
+eha0a = ["async", "dep:eha0a", "dep:eh1"]
+ip_in_core = ["defmt?/ip_in_core"]
+std = []
 
 [dependencies]
-defmt = { version = "0.3", optional = true }
+defmt = { version = "0.3.4", optional = true }
 eh0 = { package = "embedded-hal", version = "0.2.7", optional = true }
 eh1 = { package = "embedded-hal", version = "=1.0.0-alpha.10", optional = true }
 eha0a = { package = "embedded-hal-async", version = "=0.2.0-alpha.1", optional = true }

--- a/ll/README.md
+++ b/ll/README.md
@@ -38,6 +38,8 @@ All features are disabled by default.
 * `eha0a`: **Nightly only.**
   Implements the [`aio::Registers`] trait for types in the [`eh1`] module
   using the `embedded-hal-async` alpha traits.
+* `ip_in_core`: **Nightly only.**
+  Use `core::net` types for `Ipv4Addr` and `SocketAddrV4`.
 * `std`: Enables conversion between [`std::net`] and [`w5500_ll::net`] types.
   This is for testing purposes only, the `std` flag will not work on
   embedded systems because it uses the standard library.

--- a/ll/src/aio.rs
+++ b/ll/src/aio.rs
@@ -103,10 +103,10 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn gar(&mut self) -> Result<Ipv4Addr, Self::Error> {
-        let mut gar = Ipv4Addr::UNSPECIFIED;
-        self.read(Reg::GAR0.addr(), COMMON_BLOCK_OFFSET, &mut gar.octets)
+        let mut gar: [u8; 4] = [0; 4];
+        self.read(Reg::GAR0.addr(), COMMON_BLOCK_OFFSET, &mut gar)
             .await?;
-        Ok::<Ipv4Addr, Self::Error>(gar)
+        Ok::<Ipv4Addr, Self::Error>(gar.into())
     }
 
     /// Set the gateway IP address.
@@ -129,7 +129,7 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn set_gar(&mut self, gar: &Ipv4Addr) -> Result<(), Self::Error> {
-        self.write(Reg::GAR0.addr(), COMMON_BLOCK_OFFSET, &gar.octets)
+        self.write(Reg::GAR0.addr(), COMMON_BLOCK_OFFSET, &gar.octets())
             .await
     }
 
@@ -154,10 +154,10 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn subr(&mut self) -> Result<Ipv4Addr, Self::Error> {
-        let mut subr = Ipv4Addr::UNSPECIFIED;
-        self.read(Reg::SUBR0.addr(), COMMON_BLOCK_OFFSET, &mut subr.octets)
+        let mut subr: [u8; 4] = [0; 4];
+        self.read(Reg::SUBR0.addr(), COMMON_BLOCK_OFFSET, &mut subr)
             .await?;
-        Ok::<Ipv4Addr, Self::Error>(subr)
+        Ok::<Ipv4Addr, Self::Error>(subr.into())
     }
 
     /// Set the subnet mask.
@@ -180,7 +180,7 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn set_subr(&mut self, subr: &Ipv4Addr) -> Result<(), Self::Error> {
-        self.write(Reg::SUBR0.addr(), COMMON_BLOCK_OFFSET, &subr.octets)
+        self.write(Reg::SUBR0.addr(), COMMON_BLOCK_OFFSET, &subr.octets())
             .await
     }
 
@@ -258,10 +258,10 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn sipr(&mut self) -> Result<Ipv4Addr, Self::Error> {
-        let mut sipr = Ipv4Addr::UNSPECIFIED;
-        self.read(Reg::SIPR0.addr(), COMMON_BLOCK_OFFSET, &mut sipr.octets)
+        let mut sipr: [u8; 4] = [0; 4];
+        self.read(Reg::SIPR0.addr(), COMMON_BLOCK_OFFSET, &mut sipr)
             .await?;
-        Ok::<Ipv4Addr, Self::Error>(sipr)
+        Ok::<Ipv4Addr, Self::Error>(sipr.into())
     }
 
     /// Set the source (client) IP address.
@@ -284,7 +284,7 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn set_sipr(&mut self, sipr: &Ipv4Addr) -> Result<(), Self::Error> {
-        self.write(Reg::SIPR0.addr(), COMMON_BLOCK_OFFSET, &sipr.octets)
+        self.write(Reg::SIPR0.addr(), COMMON_BLOCK_OFFSET, &sipr.octets())
             .await
     }
 
@@ -1006,10 +1006,10 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn uipr(&mut self) -> Result<Ipv4Addr, Self::Error> {
-        let mut uipr = Ipv4Addr::UNSPECIFIED;
-        self.read(Reg::UIPR0.addr(), COMMON_BLOCK_OFFSET, &mut uipr.octets)
+        let mut uipr: [u8; 4] = [0; 4];
+        self.read(Reg::UIPR0.addr(), COMMON_BLOCK_OFFSET, &mut uipr)
             .await?;
-        Ok::<Ipv4Addr, Self::Error>(uipr)
+        Ok::<Ipv4Addr, Self::Error>(uipr.into())
     }
 
     /// Get the unreachable port.
@@ -1502,10 +1502,10 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn sn_dipr(&mut self, sn: Sn) -> Result<Ipv4Addr, Self::Error> {
-        let mut dipr: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
-        self.read(SnReg::DIPR0.addr(), sn.block(), &mut dipr.octets)
+        let mut dipr: [u8; 4] = [0; 4];
+        self.read(SnReg::DIPR0.addr(), sn.block(), &mut dipr)
             .await?;
-        Ok::<Ipv4Addr, Self::Error>(dipr)
+        Ok::<Ipv4Addr, Self::Error>(dipr.into())
     }
 
     /// Set the socket destination IP address.
@@ -1532,7 +1532,7 @@ pub trait Registers {
     /// # Ok(()) }
     /// ```
     async fn set_sn_dipr(&mut self, sn: Sn, dipr: &Ipv4Addr) -> Result<(), Self::Error> {
-        self.write(SnReg::DIPR0.addr(), sn.block(), &dipr.octets)
+        self.write(SnReg::DIPR0.addr(), sn.block(), &dipr.octets())
             .await
     }
 
@@ -1618,11 +1618,16 @@ pub trait Registers {
     /// #   ehm1::spi::Transaction::read_vec(vec![0, 0, 0, 0, 0, 0]),
     /// #   ehm1::spi::Transaction::transaction_end(),
     /// # ]);
-    /// use w5500_ll::{aio::Registers, eh1::vdm::W5500, net::SocketAddrV4, Sn};
+    /// use w5500_ll::{
+    ///     aio::Registers,
+    ///     eh1::vdm::W5500,
+    ///     net::{Ipv4Addr, SocketAddrV4},
+    ///     Sn,
+    /// };
     ///
     /// let mut w5500 = W5500::new(spi);
     /// let addr = w5500.sn_dest(Sn::Sn0).await?;
-    /// assert_eq!(addr, SocketAddrV4::default());
+    /// assert_eq!(addr, SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0));
     /// # Ok(()) }
     /// ```
     async fn sn_dest(&mut self, sn: Sn) -> Result<SocketAddrV4, Self::Error> {
@@ -1664,10 +1669,10 @@ pub trait Registers {
     /// ```
     async fn set_sn_dest(&mut self, sn: Sn, addr: &SocketAddrV4) -> Result<(), Self::Error> {
         let buf: [u8; 6] = [
-            addr.ip().octets[0],
-            addr.ip().octets[1],
-            addr.ip().octets[2],
-            addr.ip().octets[3],
+            addr.ip().octets()[0],
+            addr.ip().octets()[1],
+            addr.ip().octets()[2],
+            addr.ip().octets()[3],
             (addr.port() >> 8) as u8,
             addr.port() as u8,
         ];

--- a/ll/src/net.rs
+++ b/ll/src/net.rs
@@ -9,15 +9,20 @@
 //! [`std::net`]: https://doc.rust-lang.org/std/net/index.html
 //! [RFC 2832]: https://github.com/rust-lang/rfcs/pull/2832
 
+#[cfg(feature = "ip_in_core")]
+pub use core::net::{Ipv4Addr, SocketAddrV4};
+
 /// Ipv4Addr address struct.
 ///
 /// Can be instantiated with [`Ipv4Addr::new`].
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Default)]
+#[cfg(not(feature = "ip_in_core"))]
 pub struct Ipv4Addr {
     /// Octets of the [`Ipv4Addr`] address.
-    pub octets: [u8; 4],
+    octets: [u8; 4],
 }
 
+#[cfg(not(feature = "ip_in_core"))]
 impl Ipv4Addr {
     /// Creates a new IPv4 address from four eight-bit octets.
     ///
@@ -31,6 +36,7 @@ impl Ipv4Addr {
     /// let addr = Ipv4Addr::new(127, 0, 0, 1);
     /// ```
     #[allow(clippy::many_single_char_names)]
+    #[must_use]
     pub const fn new(a: u8, b: u8, c: u8, d: u8) -> Ipv4Addr {
         Ipv4Addr {
             octets: [a, b, c, d],
@@ -73,6 +79,22 @@ impl Ipv4Addr {
     /// ```
     pub const BROADCAST: Self = Ipv4Addr::new(255, 255, 255, 255);
 
+    /// Returns the four eight-bit integers that make up this address.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use w5500_ll::net::Ipv4Addr;
+    ///
+    /// let addr = Ipv4Addr::new(127, 0, 0, 1);
+    /// assert_eq!(addr.octets(), [127, 0, 0, 1]);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub const fn octets(&self) -> [u8; 4] {
+        self.octets
+    }
+
     /// Returns [`true`] for the special 'unspecified' address (0.0.0.0).
     ///
     /// This property is defined in _UNIX Network Programming, Second Edition_,
@@ -88,6 +110,7 @@ impl Ipv4Addr {
     /// assert_eq!(Ipv4Addr::new(0, 0, 0, 0).is_unspecified(), true);
     /// assert_eq!(Ipv4Addr::new(45, 22, 13, 197).is_unspecified(), false);
     /// ```
+    #[must_use]
     pub const fn is_unspecified(&self) -> bool {
         self.octets[0] == 0 && self.octets[1] == 0 && self.octets[2] == 0 && self.octets[3] == 0
     }
@@ -106,6 +129,7 @@ impl Ipv4Addr {
     /// assert_eq!(Ipv4Addr::new(127, 0, 0, 1).is_loopback(), true);
     /// assert_eq!(Ipv4Addr::new(45, 22, 13, 197).is_loopback(), false);
     /// ```
+    #[must_use]
     pub const fn is_loopback(&self) -> bool {
         self.octets[0] == 127
     }
@@ -134,6 +158,7 @@ impl Ipv4Addr {
     /// assert_eq!(Ipv4Addr::new(192, 169, 0, 2).is_private(), false);
     /// ```
     #[allow(clippy::manual_range_contains)]
+    #[must_use]
     pub const fn is_private(&self) -> bool {
         match self.octets {
             [10, ..] => true,
@@ -158,6 +183,7 @@ impl Ipv4Addr {
     /// assert_eq!(Ipv4Addr::new(169, 254, 10, 65).is_link_local(), true);
     /// assert_eq!(Ipv4Addr::new(16, 89, 10, 65).is_link_local(), false);
     /// ```
+    #[must_use]
     pub const fn is_link_local(&self) -> bool {
         matches!(self.octets, [169, 254, ..])
     }
@@ -178,6 +204,7 @@ impl Ipv4Addr {
     /// assert_eq!(Ipv4Addr::new(236, 168, 10, 65).is_multicast(), true);
     /// assert_eq!(Ipv4Addr::new(172, 16, 10, 65).is_multicast(), false);
     /// ```
+    #[must_use]
     pub const fn is_multicast(&self) -> bool {
         self.octets[0] >= 224 && self.octets[0] <= 239
     }
@@ -196,6 +223,7 @@ impl Ipv4Addr {
     /// assert_eq!(Ipv4Addr::new(255, 255, 255, 255).is_broadcast(), true);
     /// assert_eq!(Ipv4Addr::new(236, 168, 10, 65).is_broadcast(), false);
     /// ```
+    #[must_use]
     pub const fn is_broadcast(&self) -> bool {
         u32::from_be_bytes(self.octets) == u32::from_be_bytes(Self::BROADCAST.octets)
     }
@@ -221,6 +249,7 @@ impl Ipv4Addr {
     /// assert_eq!(Ipv4Addr::new(193, 34, 17, 19).is_documentation(), false);
     /// ```
     #[allow(clippy::match_like_matches_macro)]
+    #[must_use]
     pub const fn is_documentation(&self) -> bool {
         match self.octets {
             [192, 0, 2, _] => true,
@@ -231,6 +260,7 @@ impl Ipv4Addr {
     }
 }
 
+#[cfg(not(feature = "ip_in_core"))]
 impl ::core::fmt::Display for Ipv4Addr {
     /// String formatter for [`Ipv4Addr`] addresses.
     fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -242,6 +272,7 @@ impl ::core::fmt::Display for Ipv4Addr {
     }
 }
 
+#[cfg(not(feature = "ip_in_core"))]
 impl From<[u8; 4]> for Ipv4Addr {
     /// Creates an `Ipv4Addr` from a four element byte array.
     ///
@@ -258,7 +289,7 @@ impl From<[u8; 4]> for Ipv4Addr {
     }
 }
 
-#[cfg(feature = "defmt")]
+#[cfg(all(feature = "defmt", not(feature = "ip_in_core")))]
 impl defmt::Format for Ipv4Addr {
     fn format(&self, fmt: defmt::Formatter) {
         defmt::write!(
@@ -272,7 +303,7 @@ impl defmt::Format for Ipv4Addr {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<std::net::Ipv4Addr> for Ipv4Addr {
     fn from(ip: std::net::Ipv4Addr) -> Self {
         Ipv4Addr::new(
@@ -284,7 +315,7 @@ impl From<std::net::Ipv4Addr> for Ipv4Addr {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<&std::net::Ipv4Addr> for Ipv4Addr {
     fn from(ip: &std::net::Ipv4Addr) -> Self {
         Ipv4Addr::new(
@@ -296,28 +327,28 @@ impl From<&std::net::Ipv4Addr> for Ipv4Addr {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<Ipv4Addr> for std::net::Ipv4Addr {
     fn from(ip: Ipv4Addr) -> Self {
         std::net::Ipv4Addr::new(ip.octets[0], ip.octets[1], ip.octets[2], ip.octets[3])
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<&Ipv4Addr> for std::net::Ipv4Addr {
     fn from(ip: &Ipv4Addr) -> Self {
         std::net::Ipv4Addr::new(ip.octets[0], ip.octets[1], ip.octets[2], ip.octets[3])
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<Ipv4Addr> for std::net::IpAddr {
     fn from(ip: Ipv4Addr) -> Self {
         std::net::IpAddr::V4(ip.into())
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<&Ipv4Addr> for std::net::IpAddr {
     fn from(ip: &Ipv4Addr) -> Self {
         std::net::IpAddr::V4(ip.into())
@@ -443,11 +474,13 @@ impl From<[u8; 6]> for Eui48Addr {
 /// [`IPv4` address]: Ipv4Addr
 /// [`std::net::SocketAddrV4`]: https://doc.rust-lang.org/std/net/struct.SocketAddrV4.html
 #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash, Default)]
+#[cfg(not(feature = "ip_in_core"))]
 pub struct SocketAddrV4 {
     ip: Ipv4Addr,
     port: u16,
 }
 
+#[cfg(not(feature = "ip_in_core"))]
 impl SocketAddrV4 {
     /// Creates a new socket address from an [`IPv4` address] and a port number.
     ///
@@ -460,6 +493,7 @@ impl SocketAddrV4 {
     ///
     /// let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// ```
+    #[must_use]
     pub const fn new(ip: Ipv4Addr, port: u16) -> SocketAddrV4 {
         SocketAddrV4 { ip, port }
     }
@@ -474,6 +508,7 @@ impl SocketAddrV4 {
     /// let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// assert_eq!(addr.ip(), &Ipv4Addr::new(127, 0, 0, 1));
     /// ```
+    #[must_use]
     pub const fn ip(&self) -> &Ipv4Addr {
         &self.ip
     }
@@ -503,6 +538,7 @@ impl SocketAddrV4 {
     /// let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     /// assert_eq!(addr.port(), 8080);
     /// ```
+    #[must_use]
     pub const fn port(&self) -> u16 {
         self.port
     }
@@ -523,6 +559,7 @@ impl SocketAddrV4 {
     }
 }
 
+#[cfg(not(feature = "ip_in_core"))]
 impl ::core::fmt::Display for SocketAddrV4 {
     /// String formatter for [`SocketAddrV4`] addresses.
     fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -530,49 +567,49 @@ impl ::core::fmt::Display for SocketAddrV4 {
     }
 }
 
-#[cfg(feature = "defmt")]
+#[cfg(all(feature = "defmt", not(feature = "ip_in_core")))]
 impl defmt::Format for SocketAddrV4 {
     fn format(&self, fmt: defmt::Formatter) {
         defmt::write!(fmt, "{:?}:{}", self.ip(), self.port())
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<std::net::SocketAddrV4> for SocketAddrV4 {
     fn from(addr: std::net::SocketAddrV4) -> Self {
         SocketAddrV4::new(addr.ip().into(), addr.port())
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<&std::net::SocketAddrV4> for SocketAddrV4 {
     fn from(addr: &std::net::SocketAddrV4) -> Self {
         SocketAddrV4::new(addr.ip().into(), addr.port())
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<SocketAddrV4> for std::net::SocketAddrV4 {
     fn from(addr: SocketAddrV4) -> Self {
         std::net::SocketAddrV4::new(addr.ip().into(), addr.port)
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<&SocketAddrV4> for std::net::SocketAddrV4 {
     fn from(addr: &SocketAddrV4) -> Self {
         std::net::SocketAddrV4::new(addr.ip().into(), addr.port)
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<&SocketAddrV4> for std::net::SocketAddr {
     fn from(addr: &SocketAddrV4) -> Self {
         std::net::SocketAddr::V4(addr.into())
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 impl From<SocketAddrV4> for std::net::SocketAddr {
     fn from(addr: SocketAddrV4) -> Self {
         std::net::SocketAddr::V4(addr.into())

--- a/ll/tests/net_convert.rs
+++ b/ll/tests/net_convert.rs
@@ -1,12 +1,12 @@
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 const STD_IPV4: std::net::Ipv4Addr = std::net::Ipv4Addr::new(1, 2, 3, 4);
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 const STD_IP: std::net::IpAddr = std::net::IpAddr::V4(STD_IPV4);
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 const W5500_IPV4: w5500_ll::net::Ipv4Addr = w5500_ll::net::Ipv4Addr::new(1, 2, 3, 4);
 
 #[test]
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 fn ip() {
     assert_eq!(w5500_ll::net::Ipv4Addr::from(STD_IPV4), W5500_IPV4);
     assert_eq!(std::net::Ipv4Addr::from(W5500_IPV4), STD_IPV4);
@@ -18,7 +18,7 @@ fn ip() {
 }
 
 #[test]
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "ip_in_core")))]
 fn socket() {
     let std_sv4: std::net::SocketAddrV4 = std::net::SocketAddrV4::new(STD_IPV4, 1234u16);
     let std_s: std::net::SocketAddr = std::net::SocketAddr::V4(std_sv4);

--- a/mqtt/Cargo.toml
+++ b/mqtt/Cargo.toml
@@ -15,13 +15,14 @@ homepage = "https://github.com/newAM/w5500-rs"
 defmt = ["w5500-hl/defmt", "dep:defmt", "w5500-tls?/defmt"]
 eh0 = ["w5500-hl/eh0"]
 eh1 = ["w5500-hl/eh1"]
+ip_in_core = ["w5500-hl/ip_in_core"]
 log = ["dep:log", "w5500-tls?/log"]
 p256-cm4 = ["w5500-tls?/p256-cm4"]
 std = ["w5500-hl/std", "w5500-tls?/std"]
 w5500-tls = ["dep:w5500-tls"]
 
 [dependencies]
-defmt = { version = "0.3", optional = true }
+defmt = { version = "0.3.4", optional = true }
 log = { version = "0.4", optional = true }
 w5500-hl = { path = "../hl", version = "0.9.0" }
 w5500-tls = { path = "../tls", version = "0.1.3", optional = true }

--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -44,14 +44,15 @@ client.subscribe(&mut w5500, "cow")?;
 
 All features are disabled by default.
 
-* `eh0`: Passthrough to [w5500-hl].
-* `eh1`: Passthrough to [w5500-hl].
-* `std`: Passthrough to [w5500-hl].
+* `eh0`: Passthrough to [`w5500-hl`].
+* `eh1`: Passthrough to [`w5500-hl`].
+* `ip_in_core`: Passthrough to [`w5500-hl`].
+* `std`: Passthrough to [`w5500-hl`].
 * `defmt`: Enable logging with `defmt`. Also a passthrough to [w5500-hl].
 * `log`: Enable logging with `log`.
 * `w5500-tls`: Enable MQTT over TLS.
 * `p256-cm4`: Passthrough to [w5500-tls].
 
-[w5500-hl]: https://crates.io/crates/w5500-hl
+[`w5500-hl`]: https://crates.io/crates/w5500-hl
 [w5500-tls]: https://crates.io/crates/w5500-tls
 [Wiznet W5500]: https://www.wiznet.io/product-item/w5500/

--- a/mqtt/src/lib.rs
+++ b/mqtt/src/lib.rs
@@ -45,15 +45,16 @@
 //!
 //! All features are disabled by default.
 //!
-//! * `eh0`: Passthrough to [w5500-hl].
-//! * `eh1`: Passthrough to [w5500-hl].
-//! * `std`: Passthrough to [w5500-hl].
+//! * `eh0`: Passthrough to [`w5500-hl`].
+//! * `eh1`: Passthrough to [`w5500-hl`].
+//! * `ip_in_core`: Passthrough to [`w5500-hl`].
+//! * `std`: Passthrough to [`w5500-hl`].
 //! * `defmt`: Enable logging with `defmt`. Also a passthrough to [w5500-hl].
 //! * `log`: Enable logging with `log`.
 //! * `w5500-tls`: Enable MQTT over TLS.
 //! * `p256-cm4`: Passthrough to [w5500-tls].
 //!
-//! [w5500-hl]: https://crates.io/crates/w5500-hl
+//! [`w5500-hl`]: https://crates.io/crates/w5500-hl
 //! [w5500-tls]: https://crates.io/crates/w5500-tls
 //! [Wiznet W5500]: https://www.wiznet.io/product-item/w5500/
 #![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))]

--- a/regsim/Cargo.toml
+++ b/regsim/Cargo.toml
@@ -13,6 +13,7 @@ homepage = "https://github.com/newAM/w5500-rs"
 
 [features]
 async = ["w5500-ll/async"]
+ip_in_core = ["w5500-ll/ip_in_core"]
 
 [dependencies]
 log = "0.4"

--- a/regsim/README.md
+++ b/regsim/README.md
@@ -13,6 +13,7 @@ code, not all features of the W5500 will be fully simulated.
 All features are disabled by default.
 
 * `async`: **Nightly only.** Implement asynchronous traits.
+* `ip_in_core`: **Nightly only.** Use `core::net` networking types.
 
 ## Notes
 

--- a/sntp/Cargo.toml
+++ b/sntp/Cargo.toml
@@ -16,13 +16,14 @@ chrono = ["dep:chrono"]
 defmt = ["w5500-hl/defmt", "dep:defmt"]
 eh0 = ["w5500-hl/eh0"]
 eh1 = ["w5500-hl/eh1"]
+ip_in_core = ["w5500-hl/ip_in_core"]
 num-rational = ["dep:num-rational"]
 std = ["w5500-hl/std"]
 time = ["dep:time"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, optional = true }
-defmt = { version = "0.3", default-features = false, optional = true }
+defmt = { version = "0.3.4", default-features = false, optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 num-rational = { version = "0.4", default-features = false, optional = true }
 time = { version = "0.3", default-features = false, optional = true }

--- a/sntp/README.md
+++ b/sntp/README.md
@@ -12,6 +12,7 @@ All features are disabled by default.
 
 * `eh0`: Passthrough to [`w5500-hl`].
 * `eh1`: Passthrough to [`w5500-hl`].
+* `ip_in_core`: Passthrough to [`w5500-hl`].
 * `std`: Passthrough to [`w5500-hl`].
 * `defmt`: Enable logging with `defmt`. Also a passthrough to [`w5500-hl`].
 * `log`: Enable logging with `log`.

--- a/sntp/src/lib.rs
+++ b/sntp/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 //! * `eh0`: Passthrough to [`w5500-hl`].
 //! * `eh1`: Passthrough to [`w5500-hl`].
+//! * `ip_in_core`: Passthrough to [`w5500-hl`].
 //! * `std`: Passthrough to [`w5500-hl`].
 //! * `defmt`: Enable logging with `defmt`. Also a passthrough to [`w5500-hl`].
 //! * `log`: Enable logging with `log`.

--- a/tls/Cargo.toml
+++ b/tls/Cargo.toml
@@ -12,9 +12,10 @@ categories = ["embedded", "hardware-support", "no-std"]
 homepage = "https://github.com/newAM/w5500-rs"
 
 [features]
+defmt = ["w5500-hl/defmt", "dep:defmt", "heapless/defmt-impl"]
 eh0 = ["w5500-hl/eh0"]
 eh1 = ["w5500-hl/eh1"]
-defmt = ["w5500-hl/defmt", "dep:defmt", "heapless/defmt-impl"]
+ip_in_core = ["w5500-hl/ip_in_core"]
 std = ["w5500-hl/std"]
 
 [dependencies]
@@ -30,7 +31,7 @@ sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional
-defmt = { version = "0.3", optional = true }
+defmt = { version = "0.3.4", optional = true }
 log = { version = "0.4", optional = true }
 p256-cm4 = { version = "0.3", optional = true }
 

--- a/tls/README.md
+++ b/tls/README.md
@@ -44,6 +44,7 @@ All features are disabled by default.
 
 * `eh0`: Passthrough to [`w5500-hl`].
 * `eh1`: Passthrough to [`w5500-hl`].
+* `ip_in_core`: Passthrough to [`w5500-hl`].
 * `std`: Passthrough to [`w5500-hl`].
 * `defmt`: Enable logging with `defmt`. Also a passthrough to [`w5500-hl`].
 * `log`: Enable logging with `log`.

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -42,6 +42,7 @@
 //!
 //! * `eh0`: Passthrough to [`w5500-hl`].
 //! * `eh1`: Passthrough to [`w5500-hl`].
+//! * `ip_in_core`: Passthrough to [`w5500-hl`].
 //! * `std`: Passthrough to [`w5500-hl`].
 //! * `defmt`: Enable logging with `defmt`. Also a passthrough to [`w5500-hl`].
 //! * `log`: Enable logging with `log`.


### PR DESCRIPTION
* [x] Add passthrough feature to other crates
* [x] Update CI to test with and without this feature
* [x] Wait for `defmt` release that includes `ip_in_core` support: https://github.com/knurling-rs/defmt/pull/733