### PR TITLE
dhcp: fix server identifier in REQUEST message

### DIFF
--- a/dhcp/src/lib.rs
+++ b/dhcp/src/lib.rs
@@ -129,8 +129,8 @@ pub struct Client<'a> {
     lease: u32,
     /// Time that the lease was obtained.
     lease_monotonic_secs: u32,
-    /// Last DHCP server
-    server: Option<Ipv4Addr>,
+    /// DHCP server identifier option
+    server_id_option: Option<Ipv4Addr>,
     /// Last XID
     xid: u32,
     /// XID generator
@@ -186,7 +186,7 @@ impl<'a> Client<'a> {
             t2: 0,
             lease: 0,
             lease_monotonic_secs: 0,
-            server: None,
+            server_id_option: None,
             xid: rand.next_u32(),
             rand,
             mac,
@@ -425,7 +425,7 @@ impl<'a> Client<'a> {
             match self.state {
                 State::Selecting => {
                     self.ip = pkt.yiaddr()?;
-                    self.server = Some(pkt.siaddr()?);
+                    self.server_id_option = pkt.dhcp_server()?;
                     pkt.done()?;
                     self.request(w5500)?;
                     self.set_state_with_timeout(State::Requesting, monotonic_secs);
@@ -600,7 +600,7 @@ impl<'a> Client<'a> {
             &self.mac,
             &self.ip,
             self.hostname,
-            self.server.as_ref().unwrap(),
+            self.server_id_option.as_ref(),
             self.xid,
         )?;
         Ok(())


### PR DESCRIPTION
Currently, the server identifier added in the REQUEST message corresponds to the siaddr retrieved in the OFFER. This is probably correct in some situations, but I noticed this does not work in my case: the REQUEST is NACK'ed by the server.

The DHCP server of my Internet box sends an OFFER containing 0.0.0.0 as next server IP, and its address (192.168.1.254) in the DHCP server identifier option (54).

From RFC2131, the next server IP (siaddr) is indeed not supposed to be used like this:

> DHCP clarifies the interpretation of the 'siaddr' field as the
> address of the server to use in the next step of the client's
> bootstrap process. A DHCP server may return its own address in the
> 'siaddr' field, if the server is prepared to supply the next
> bootstrap service (e.g., delivery of an operating system executable
> image). A DHCP server always returns its own address in the 'server
> identifier' option.

Additionally, in dhclient sources (see the 2nd link), we can see that next_srv_addr (filled from siaddr) is just passed to the script. On the other hand, the server identifier option is added in the REQUEST if it was present in the OFFER.

This patch tries to imitate this behavior: if the option was present in the OFFER, it will be added in the REQUEST.

Fixes: 3cb6a20f8556 ("DHCP: add ServerId in REQUEST message")
Link: https://www.rfc-editor.org/rfc/rfc2131.txt
Link: https://github.com/isc-projects/dhcp/blob/master/client/dhclient.c