### PR TITLE
CI: beta -> stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "beta"  # stable
+          - "stable"
           - "nightly"
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "beta"  # stable
+          - "stable"
           - "nightly"
         target:
           - "thumbv6m-none-eabi"


### PR DESCRIPTION
Merge on 2023-12-28 when rust 1.75.0 is released: https://www.whatrustisit.com/