### PR TITLE
mqtt: add login credentials

### DIFF
--- a/mqtt/tests/connect.rs
+++ b/mqtt/tests/connect.rs
@@ -50,6 +50,47 @@ fn connect_no_client_id() {
 }
 
 #[test]
+fn connect_with_login() {
+    const PORT: u16 = 12345;
+    let mut client: Client =
+        Client::new(Sn0, SRC_PORT, SocketAddrV4::new(Ipv4Addr::LOCALHOST, PORT));
+    client.set_credentials("mqtt-user", "password");
+
+    let mut fixture = Fixture::with_client(client, PORT);
+    assert!(matches!(
+        fixture.client_process().unwrap(),
+        Event::CallAfter(10)
+    ));
+    fixture.server.accept();
+    assert!(matches!(
+        fixture.client_process().unwrap(),
+        Event::CallAfter(10)
+    ));
+    fixture.server_expect(Packet::Connect(Connect {
+        protocol: V5,
+        keep_alive: 900,
+        client_id: "".to_string(),
+        clean_session: true,
+        last_will: None,
+        login: Some(mqttbytes::v5::Login {
+            username: "mqtt-user".to_string(),
+            password: "password".to_string(),
+        }),
+        properties: Some(ConnectProperties {
+            session_expiry_interval: None,
+            receive_maximum: None,
+            max_packet_size: Some(2048),
+            topic_alias_max: None,
+            request_response_info: None,
+            request_problem_info: None,
+            user_properties: vec![],
+            authentication_method: None,
+            authentication_data: None,
+        }),
+    }));
+}
+
+#[test]
 fn connect_fail() {
     const PORT: u16 = 12344;
     let client: Client = Client::new(Sn0, SRC_PORT, SocketAddrV4::new(Ipv4Addr::LOCALHOST, PORT));


### PR DESCRIPTION
The following PR adds support for password protected servers - specifically enabling connection with HomeAssistant MQTT add-on.