### PR TITLE
tls: fix bug in prior bugfix

### DIFF
--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -844,7 +844,7 @@ impl<'hn, 'psk, 'b, const N: usize> Client<'hn, 'psk, 'b, N> {
                 }
             }
             ContentType::ApplicationData => {
-                if self.state == State::SendFinished {
+                if self.state == State::Connected {
                     Ok(Some(Event::ApplicationData))
                 } else {
                     error!("unexpected ApplicationData in state {:?}", self.state);


### PR DESCRIPTION
The fix in 6089396bd804ddc18356c5c1b6b61422b43105e4 should use the Connected state, not the SendFinished State.